### PR TITLE
Improve JWT error handling

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -26,7 +26,9 @@ def require_auth(role=None):
             try:
                 payload = jwt.decode(hdr[1], JWT_SECRET, algorithms=['HS256'])
             except jwt.ExpiredSignatureError:
-                return jsonify({'msg':'token expired'}), 401
+                return jsonify({'msg': 'token expired'}), 401
+            except jwt.InvalidTokenError:
+                return jsonify({'msg': 'token invalid'}), 401
             if role and payload['role'] not in role.split('|'):
                 return jsonify({'msg':'forbidden'}), 403
             request.user = payload

--- a/tests/test_invalid_token.py
+++ b/tests/test_invalid_token.py
@@ -1,0 +1,10 @@
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'backend'))
+from app import app
+
+
+def test_garbled_token():
+    with app.test_client() as client:
+        resp = client.get('/api/my-results', headers={'Authorization': 'Bearer notajwt'})
+        assert resp.status_code == 401
+        assert resp.get_json()['msg'] == 'token invalid'


### PR DESCRIPTION
## Summary
- refine token checks in `require_auth`
- add a pytest for invalid tokens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b62773788330b1235daa8e428a1b