### PR TITLE
Restrict task modifications to teachers

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -73,9 +73,11 @@ def task_dict(t):
 
 
 @app.route('/api/tasks', methods=['GET', 'POST'])
-@require_auth()
+@require_auth(role='student|teacher|admin')
 def tasks():
     if request.method == 'POST':
+        if request.user['role'] not in ('teacher', 'admin'):
+            return jsonify({'msg': 'forbidden'}), 403
         d = request.json
         t = Task(name=d['name'], effort=d.get('effort', 0),
                  deadline=datetime.datetime.fromisoformat(d['deadline']) if d.get('deadline') else None,
@@ -87,8 +89,10 @@ def tasks():
 
 
 @app.route('/api/tasks/<int:tid>', methods=['PUT'])
-@require_auth()
+@require_auth(role='student|teacher|admin')
 def update_task(tid):
+    if request.user['role'] not in ('teacher', 'admin'):
+        return jsonify({'msg': 'forbidden'}), 403
     t = Task.query.get_or_404(tid)
     d = request.json
     for k in ['name', 'effort', 'status']:


### PR DESCRIPTION
## Summary
- limit POST /api/tasks and PUT /api/tasks/<id> so only teachers/admins may change tasks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b627422c8330b069fd347369b86c