### PR TITLE
Fix token handling on account page

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -90,10 +90,11 @@
     <script>
       // ===== Проверяем токен =====
       const tokenKey = "pyToken";
-      const user = localStorage.getItem(tokenKey);
-      if (!user) {
-        location.replace("login.html");
-      }
+      const token = localStorage.getItem(tokenKey);
+      if (!token) location.replace("login.html");
+      const parsed = jwt_decode(token);
+      document.getElementById("dashName").textContent = parsed.u;
+      const currentUid = parsed.uid;
 
       // ===== Меню =====
       const menuToggle = document.getElementById("menuToggle");
@@ -109,7 +110,6 @@
       };
 
       // ===== Заполняем данные =====
-      document.getElementById("dashName").textContent = user;
       const tbody = document.getElementById("dashBody");
       function load(){
         fetch('/api/tasks',{headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})
@@ -129,7 +129,6 @@
             });
           });
       }
-      const currentUid=jwt_decode(localStorage.getItem(tokenKey)).uid;
       load();
 
       // ===== Выход =====


### PR DESCRIPTION
## Summary
- load and decode token in one place on the account page
- use parsed values for username and UID

## Testing
- `python -m py_compile backend/models.py backend/auth.py backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846b62654d88330b8b11bd67ee1a5dd