### PR TITLE
Add leader dashboard and risk logging

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,14 +1,16 @@
 import datetime
 import functools
 import os
+import csv
+import io
 from pathlib import Path
 
 import jwt  # PyJWT
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, Response
 from flask_cors import CORS
 
 from auth import auth_bp
-from models import Task, Result, User, db
+from models import Task, Result, User, Comment, RiskEvent, db
 
 # ── Flask set‑up ────────────────────────────────────────────────────────────────
 ROOT = Path(__file__).resolve().parent
@@ -122,6 +124,21 @@ def all_results():
         ]
     )
 
+
+@app.route("/api/profile", methods=["GET", "PATCH"])
+@require_auth()
+def profile():
+    u = User.query.get_or_404(request.user["uid"])
+    if request.method == "GET":
+        return jsonify({"id": u.id, "username": u.username, "timezone": u.timezone})
+    data = request.json
+    if "timezone" in data:
+        u.timezone = data["timezone"]
+    if "username" in data:
+        u.username = data["username"]
+    db.session.commit()
+    return "", 204
+
 # ── API: tasks ──────────────────────────────────────────────────────────────────
 
 def task_dict(t: Task):
@@ -132,6 +149,8 @@ def task_dict(t: Task):
         "deadline": t.deadline.isoformat() if t.deadline else None,
         "assignee": t.user_id,
         "status": t.status,
+        "progress": t.progress,
+        "priority": t.priority,
     }
 
 
@@ -148,6 +167,7 @@ def tasks():
             effort=d.get("effort", 0),
             deadline=datetime.datetime.fromisoformat(d["deadline"]) if d.get("deadline") else None,
             status=d.get("status", "open"),
+            priority=d.get("priority", "normal"),
         )
         db.session.add(t)
         db.session.commit()
@@ -158,6 +178,137 @@ def tasks():
     return jsonify([task_dict(t) for t in rows])
 
 
+@app.route("/api/tasks/<int:tid>", methods=["GET", "PATCH"])
+@require_auth(role="student|teacher|admin")
+def task_detail(tid):
+    t = Task.query.get_or_404(tid)
+    if request.method == "GET":
+        comments = Comment.query.filter_by(task_id=tid).all()
+        return jsonify(
+            {
+                **task_dict(t),
+                "comments": [
+                    {
+                        "user": c.user_id,
+                        "text": c.text,
+                        "date": c.created_at.isoformat(),
+                    }
+                    for c in comments
+                ],
+            }
+        )
+
+    # PATCH
+    d = request.json
+    if "progress" in d:
+        if request.user["uid"] != t.user_id and request.user["role"] not in (
+            "teacher",
+            "admin",
+        ):
+            return jsonify({"msg": "forbidden"}), 403
+        t.progress = int(d["progress"])
+        if t.progress >= 100:
+            t.status = "pending_review"
+        now = datetime.datetime.utcnow()
+        if t.deadline and t.progress < 100 and t.deadline < now:
+            db.session.add(
+                RiskEvent(
+                    task_id=tid,
+                    message="Просрочка",
+                    created_at=now,
+                )
+            )
+        elif t.deadline and t.progress < 50 and (t.deadline - now).days <= 2:
+            db.session.add(
+                RiskEvent(
+                    task_id=tid,
+                    message="Риск задержки",
+                    created_at=now,
+                )
+            )
+    db.session.commit()
+    return "", 204
+
+
+@app.route("/api/tasks/export")
+@require_auth(role="student|teacher|admin")
+def export_tasks():
+    """Return all tasks as a CSV file."""
+    rows = Task.query.all()
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["id", "name", "effort", "deadline", "assignee", "status", "priority"])
+    for t in rows:
+        writer.writerow(
+            [
+                t.id,
+                t.name,
+                t.effort,
+                t.deadline.isoformat() if t.deadline else "",
+                t.user_id or "",
+                t.status,
+                t.priority,
+            ]
+        )
+    return Response(
+        buf.getvalue(),
+        headers={
+            "Content-Type": "text/csv",
+            "Content-Disposition": "attachment; filename=tasks.csv",
+        },
+    )
+
+
+@app.route("/api/risk-events")
+@require_auth(role="teacher|admin")
+def risk_events():
+    rows = RiskEvent.query.order_by(RiskEvent.created_at.desc()).all()
+    return jsonify(
+        [
+            {
+                "id": r.id,
+                "task": r.task_id,
+                "message": r.message,
+                "date": r.created_at.isoformat(),
+            }
+            for r in rows
+        ]
+    )
+
+
+@app.route("/api/reports")
+@require_auth(role="teacher|admin")
+def reports():
+    q = Task.query
+    if "from" in request.args:
+        q = q.filter(Task.deadline >= datetime.datetime.fromisoformat(request.args["from"]))
+    if "to" in request.args:
+        q = q.filter(Task.deadline <= datetime.datetime.fromisoformat(request.args["to"]))
+    rows = q.all()
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["id", "name", "effort", "deadline", "assignee", "status", "priority"])
+    for t in rows:
+        writer.writerow(
+            [
+                t.id,
+                t.name,
+                t.effort,
+                t.deadline.isoformat() if t.deadline else "",
+                t.user_id or "",
+                t.status,
+                t.priority,
+            ]
+        )
+    return Response(
+        buf.getvalue(),
+        headers={
+            "Content-Type": "text/csv",
+            "Content-Disposition": "attachment; filename=report.csv",
+        },
+    )
+
+
 @app.route("/api/tasks/<int:tid>", methods=["PUT"])
 @require_auth(role="student|teacher|admin")
 def update_task(tid):
@@ -165,7 +316,7 @@ def update_task(tid):
         return jsonify({"msg": "forbidden"}), 403
     t = Task.query.get_or_404(tid)
     d = request.json
-    for k in ("name", "effort", "status"):
+    for k in ("name", "effort", "status", "priority"):
         if k in d:
             setattr(t, k, d[k])
     if "deadline" in d:
@@ -198,6 +349,22 @@ def release_task(tid):
     t.status = "open"
     db.session.commit()
     return "", 204
+
+
+@app.route("/api/tasks/<int:tid>/comment", methods=["POST"])
+@require_auth(role="student|teacher|admin")
+def add_comment(tid):
+    t = Task.query.get_or_404(tid)
+    d = request.json
+    c = Comment(
+        task_id=tid,
+        user_id=request.user["uid"],
+        text=d.get("text", ""),
+        created_at=datetime.datetime.utcnow(),
+    )
+    db.session.add(c)
+    db.session.commit()
+    return "", 201
 
 # ── Main entry ─────────────────────────────────────────────────────────────────
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -6,6 +6,7 @@ class User(db.Model):
     username = db.Column(db.String(80), unique=True, nullable=False)
     password = db.Column(db.String(128), nullable=False)  # bcrypt-хэш
     role     = db.Column(db.String(10), default='student')  # student|teacher|admin
+    timezone = db.Column(db.String(40), default='UTC')
 
 class Result(db.Model):
     id        = db.Column(db.Integer, primary_key=True)
@@ -23,3 +24,21 @@ class Task(db.Model):
     deadline = db.Column(db.DateTime)
     user_id  = db.Column(db.Integer, db.ForeignKey('user.id'))
     status   = db.Column(db.String(20), default='open')  # open|in_progress|done
+    progress = db.Column(db.Integer, default=0)  # percent complete
+    priority = db.Column(db.String(20), default='normal')
+
+
+class Comment(db.Model):
+    id        = db.Column(db.Integer, primary_key=True)
+    task_id   = db.Column(db.Integer, db.ForeignKey('task.id'))
+    user_id   = db.Column(db.Integer, db.ForeignKey('user.id'))
+    text      = db.Column(db.String(200))
+    created_at = db.Column(db.DateTime)
+
+
+class RiskEvent(db.Model):
+    id        = db.Column(db.Integer, primary_key=True)
+    task_id   = db.Column(db.Integer, db.ForeignKey('task.id'))
+    message   = db.Column(db.String(200))
+    created_at = db.Column(db.DateTime)
+

--- a/backend/static/account.html
+++ b/backend/static/account.html
@@ -47,6 +47,10 @@
           <a href="index.html" class="dropdown-item">Главная</a>
           <a href="tasks.html" class="dropdown-item">Задачи</a>
           <a href="schedule.html" class="dropdown-item">Календарь</a>
+          <a href="profile.html" class="dropdown-item">Профиль</a>
+          <a href="tl-dashboard.html" class="dropdown-item">TL Панель</a>
+          <a href="risk-log.html" class="dropdown-item">Риски</a>
+          <a href="reports.html" class="dropdown-item">Отчёты</a>
           <span id="logoutBtn" class="dropdown-item">Выйти</span>
         </nav>
       </div>

--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -61,6 +61,10 @@
           <a href="account.html" class="dropdown-item">Аккаунт</a>
           <a href="tasks.html" class="dropdown-item">Задачи</a>
           <a href="schedule.html" class="dropdown-item">Календарь</a>
+          <a href="profile.html" class="dropdown-item">Профиль</a>
+          <a href="tl-dashboard.html" class="dropdown-item">TL Панель</a>
+          <a href="risk-log.html" class="dropdown-item">Риски</a>
+          <a href="reports.html" class="dropdown-item">Отчёты</a>
         </nav>
       </div>
     </header>

--- a/backend/static/login.html
+++ b/backend/static/login.html
@@ -56,6 +56,10 @@
           <a href="account.html" class="dropdown-item">Аккаунт</a>
           <a href="tasks.html" class="dropdown-item">Задачи</a>
           <a href="schedule.html" class="dropdown-item">Календарь</a>
+          <a href="profile.html" class="dropdown-item">Профиль</a>
+          <a href="tl-dashboard.html" class="dropdown-item">TL Панель</a>
+          <a href="risk-log.html" class="dropdown-item">Риски</a>
+          <a href="reports.html" class="dropdown-item">Отчёты</a>
         </nav>
       </div>
     </header>

--- a/backend/static/profile.html
+++ b/backend/static/profile.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Настройки профиля</title>
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+</head>
+<body>
+<header class="header">
+  <span class="header-text">Сервис управления заданиями</span>
+  <div class="dropdown">
+    <i id="menuToggle" class="fas fa-list" style="font-size:2rem;cursor:pointer"></i>
+    <nav id="dropdownMenu" class="dropdown-content">
+      <a href="index.html" class="dropdown-item">Главная</a>
+      <a href="tasks.html" class="dropdown-item">Задачи</a>
+      <a href="schedule.html" class="dropdown-item">Календарь</a>
+      <a href="tl-dashboard.html" class="dropdown-item">TL Панель</a>
+      <a href="risk-log.html" class="dropdown-item">Риски</a>
+      <a href="reports.html" class="dropdown-item">Отчёты</a>
+    </nav>
+  </div>
+</header>
+<main class="main">
+  <section class="info-section" style="max-width:400px;margin:auto">
+    <h2>Настройки</h2>
+    <label>Имя пользователя</label>
+    <input id="username" type="text" style="width:100%;padding:0.5rem;margin:0.3rem 0 1rem">
+    <label>Часовой пояс</label>
+    <input id="tz" type="text" style="width:100%;padding:0.5rem;margin:0.3rem 0 1rem" placeholder="UTC">
+    <div class="buttons" style="justify-content:center">
+      <button class="btn" id="save">Сохранить</button>
+      <button class="btn" id="logout" style="background:#d9534f;margin-left:0.5rem">Выйти</button>
+    </div>
+  </section>
+</main>
+<script src="scripts.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jwt-decode@4/build/cjs/index.js"></script>
+<script>
+const API='/api', tokenKey='pyToken';
+document.addEventListener('DOMContentLoaded',()=>{
+  const token=localStorage.getItem(tokenKey);
+  if(!token) location.replace('login.html');
+  fetch(API+'/profile',{headers:{'Authorization':'Bearer '+token}})
+    .then(r=>r.json()).then(d=>{document.getElementById('username').value=d.username;document.getElementById('tz').value=d.timezone;});
+  document.getElementById('save').onclick=()=>{
+    const body={username:document.getElementById('username').value.trim(),timezone:document.getElementById('tz').value.trim()};
+    fetch(API+'/profile',{method:'PATCH',headers:{'Content-Type':'application/json','Authorization':'Bearer '+token},body:JSON.stringify(body)}).then(()=>alert('Сохранено'));
+  };
+  document.getElementById('logout').onclick=()=>{localStorage.removeItem(tokenKey);location.replace('login.html');};
+});
+</script>
+</body>
+</html>
+

--- a/backend/static/reports.html
+++ b/backend/static/reports.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Отчёты</title>
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+</head>
+<body>
+<header class="header">
+  <span class="header-text">Отчёты</span>
+  <div class="dropdown">
+    <i id="menuToggle" class="fas fa-list" style="font-size:2rem;cursor:pointer"></i>
+    <nav id="dropdownMenu" class="dropdown-content">
+      <a href="tl-dashboard.html" class="dropdown-item">TL Панель</a>
+    </nav>
+  </div>
+</header>
+<main class="main">
+  <section class="info-section" style="max-width:400px;margin:auto">
+    <label>С</label>
+    <input id="from" type="date" style="width:100%">
+    <label>По</label>
+    <input id="to" type="date" style="width:100%">
+    <div class="buttons" style="justify-content:center;margin-top:1rem">
+      <button id="csvBtn" class="btn">Скачать CSV</button>
+    </div>
+  </section>
+</main>
+<script src="scripts.js"></script>
+<script>
+const API='/api', tokenKey='pyToken';
+function download(){
+  const from=document.getElementById('from').value;
+  const to=document.getElementById('to').value;
+  const url=`${API}/reports?from=${from}&to=${to}`;
+  fetch(url,{headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})
+    .then(r=>r.blob()).then(b=>{
+      const u=URL.createObjectURL(b);
+      const a=document.createElement('a');
+      a.href=u;a.download='report.csv';a.click();URL.revokeObjectURL(u);
+    });
+}
+if(!localStorage.getItem(tokenKey)) location.replace('login.html');
+document.addEventListener('DOMContentLoaded',()=>{
+  document.getElementById('csvBtn').onclick=download;
+});
+</script>
+</body>
+</html>

--- a/backend/static/risk-log.html
+++ b/backend/static/risk-log.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Журнал рисков</title>
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+</head>
+<body>
+<header class="header">
+  <span class="header-text">Журнал рисков</span>
+  <div class="dropdown">
+    <i id="menuToggle" class="fas fa-list" style="font-size:2rem;cursor:pointer"></i>
+    <nav id="dropdownMenu" class="dropdown-content">
+      <a href="tl-dashboard.html" class="dropdown-item">TL Панель</a>
+    </nav>
+  </div>
+</header>
+<main class="main">
+  <section class="info-section">
+    <table id="riskTable" style="width:100%;border-collapse:collapse">
+      <thead>
+        <tr><th>Дата</th><th>Задача</th><th>Сообщение</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </section>
+</main>
+<script src="scripts.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jwt-decode@4/build/cjs/index.js"></script>
+<script>
+const API='/api', tokenKey='pyToken';
+const tbody=document.querySelector('#riskTable tbody');
+function load(){
+  fetch(API+'/risk-events',{headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})
+    .then(r=>r.json()).then(list=>{
+      tbody.innerHTML='';
+      list.forEach(e=>{
+        const tr=document.createElement('tr');
+        tr.innerHTML=`<td>${e.date.split('T')[0]}</td><td>${e.task}</td><td>${e.message}</td>`;
+        tbody.appendChild(tr);
+      });
+    });
+}
+if(!localStorage.getItem(tokenKey)) location.replace('login.html');
+document.addEventListener('DOMContentLoaded',load);
+</script>
+</body>
+</html>

--- a/backend/static/schedule.html
+++ b/backend/static/schedule.html
@@ -17,6 +17,10 @@
       <a href="account.html" class="dropdown-item">Аккаунт</a>
       <a href="tasks.html" class="dropdown-item">Задачи</a>
       <a href="schedule.html" class="dropdown-item">Календарь</a>
+      <a href="profile.html" class="dropdown-item">Профиль</a>
+      <a href="tl-dashboard.html" class="dropdown-item">TL Панель</a>
+      <a href="risk-log.html" class="dropdown-item">Риски</a>
+      <a href="reports.html" class="dropdown-item">Отчёты</a>
     </nav>
   </div>
 </header>

--- a/backend/static/task.html
+++ b/backend/static/task.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Детали задачи</title>
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+</head>
+<body>
+<header class="header">
+  <span class="header-text">Сервис управления заданиями</span>
+  <div class="dropdown">
+    <i id="menuToggle" class="fas fa-list" style="font-size:2rem;cursor:pointer"></i>
+    <nav id="dropdownMenu" class="dropdown-content">
+      <a href="index.html" class="dropdown-item">Главная</a>
+      <a href="tasks.html" class="dropdown-item">Задачи</a>
+      <a href="schedule.html" class="dropdown-item">Календарь</a>
+    </nav>
+  </div>
+</header>
+<main class="main">
+  <section class="info-section" id="info">
+    <h2 id="taskName">Задача</h2>
+    <p>Трудоёмкость: <span id="taskEffort"></span></p>
+    <p>Дедлайн: <span id="taskDeadline"></span></p>
+    <p>Приоритет: <span id="taskPriority"></span></p>
+    <div style="margin:1rem 0">
+      <label>Прогресс: <span id="progVal">0</span>%</label>
+      <input type="range" id="progress" min="0" max="100" value="0" style="width:100%">
+      <button class="btn" id="saveBtn" style="margin-top:0.5rem">Сохранить</button>
+    </div>
+  </section>
+  <section class="info-section">
+    <h3>Комментарии</h3>
+    <ul id="comments" style="list-style:none;padding:0"></ul>
+    <textarea id="commentText" style="width:100%;height:60px"></textarea>
+    <button class="btn" id="commentBtn" style="margin-top:0.5rem">Отправить</button>
+  </section>
+</main>
+<script src="scripts.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jwt-decode@4/build/cjs/index.js"></script>
+<script>
+const API='/api', tokenKey='pyToken';
+const params=new URLSearchParams(location.search);
+const taskId=parseInt(params.get('id'));
+let currentUser=null;
+function load(){
+  fetch(API+`/tasks/${taskId}`,{headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})
+    .then(r=>r.json()).then(show);
+}
+function show(d){
+  document.getElementById('taskName').textContent=d.name;
+  document.getElementById('taskEffort').textContent=d.effort;
+  document.getElementById('taskDeadline').textContent=d.deadline?d.deadline.split('T')[0]:'';
+  document.getElementById('taskPriority').textContent=d.priority;
+  document.getElementById('progress').value=d.progress;
+  document.getElementById('progVal').textContent=d.progress;
+  const list=document.getElementById('comments');
+  list.innerHTML='';
+  d.comments.forEach(c=>{
+    const li=document.createElement('li');
+    li.textContent=`${c.user}: ${c.text}`;
+    list.appendChild(li);
+  });
+}
+function saveProgress(){
+  const val=document.getElementById('progress').value;
+  fetch(API+`/tasks/${taskId}`,{
+    method:'PATCH',
+    headers:{'Content-Type':'application/json','Authorization':'Bearer '+localStorage.getItem(tokenKey)},
+    body:JSON.stringify({progress:val})
+  }).then(()=>load());
+}
+function addComment(){
+  const text=document.getElementById('commentText').value.trim();
+  if(!text) return;
+  fetch(API+`/tasks/${taskId}/comment`,{
+    method:'POST',
+    headers:{'Content-Type':'application/json','Authorization':'Bearer '+localStorage.getItem(tokenKey)},
+    body:JSON.stringify({text})
+  }).then(()=>{document.getElementById('commentText').value='';load();});
+}
+document.addEventListener('DOMContentLoaded',()=>{
+  if(!localStorage.getItem(tokenKey)) location.replace('login.html');
+  currentUser=jwt_decode(localStorage.getItem(tokenKey)).uid;
+  load();
+  document.getElementById('progress').oninput=e=>document.getElementById('progVal').textContent=e.target.value;
+  document.getElementById('saveBtn').onclick=saveProgress;
+  document.getElementById('commentBtn').onclick=addComment;
+});
+</script>
+</body>
+</html>

--- a/backend/static/task_edit.html
+++ b/backend/static/task_edit.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Редактор задачи</title>
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+</head>
+<body>
+<header class="header">
+  <span class="header-text">Редактирование задачи</span>
+  <div class="dropdown">
+    <i id="menuToggle" class="fas fa-list" style="font-size:2rem;cursor:pointer"></i>
+    <nav id="dropdownMenu" class="dropdown-content">
+      <a href="tl-dashboard.html" class="dropdown-item">TL Панель</a>
+    </nav>
+  </div>
+</header>
+<main class="main">
+  <section class="info-section" style="max-width:400px;margin:auto">
+    <label>Часы</label>
+    <input id="effort" type="number" style="width:100%">
+    <label>Дедлайн</label>
+    <input id="deadline" type="date" style="width:100%">
+    <label>Приоритет</label>
+    <input id="priority" type="text" style="width:100%">
+    <div class="buttons" style="justify-content:center;margin-top:1rem">
+      <button id="saveBtn" class="btn">Сохранить</button>
+    </div>
+  </section>
+</main>
+<script src="scripts.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jwt-decode@4/build/cjs/index.js"></script>
+<script>
+const API='/api', tokenKey='pyToken';
+const id=parseInt(new URLSearchParams(location.search).get('id'));
+function load(){
+  fetch(API+`/tasks/${id}`,{headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})
+    .then(r=>r.json()).then(d=>{
+      document.getElementById('effort').value=d.effort||0;
+      document.getElementById('priority').value=d.priority||'';
+      if(d.deadline) document.getElementById('deadline').value=d.deadline.split('T')[0];
+    });
+}
+function save(){
+  const body={
+    effort:parseInt(document.getElementById('effort').value||0),
+    deadline:document.getElementById('deadline').value,
+    priority:document.getElementById('priority').value.trim()
+  };
+  fetch(API+`/tasks/${id}`,{method:'PUT',headers:{'Content-Type':'application/json','Authorization':'Bearer '+localStorage.getItem(tokenKey)},body:JSON.stringify(body)})
+    .then(()=>location.replace('tl-dashboard.html'));
+}
+if(!localStorage.getItem(tokenKey)) location.replace('login.html');
+document.addEventListener('DOMContentLoaded',()=>{load();document.getElementById('saveBtn').onclick=save;});
+</script>
+</body>
+</html>

--- a/backend/static/tasks.html
+++ b/backend/static/tasks.html
@@ -17,6 +17,10 @@
         <a href="account.html" class="dropdown-item">Аккаунт</a>
         <a href="tasks.html" class="dropdown-item">Задачи</a>
         <a href="schedule.html" class="dropdown-item">Календарь</a>
+        <a href="profile.html" class="dropdown-item">Профиль</a>
+        <a href="tl-dashboard.html" class="dropdown-item">TL Панель</a>
+        <a href="risk-log.html" class="dropdown-item">Риски</a>
+        <a href="reports.html" class="dropdown-item">Отчёты</a>
       </nav>
     </div>
   </header>
@@ -24,6 +28,7 @@
   <main class="main">
     <section class="info-section">
       <h2>Список задач</h2>
+      <button id="exportBtn" class="btn" style="margin-bottom:1rem">Экспорт CSV</button>
       <table style="width:100%;border-collapse:collapse" id="taskTable">
         <thead style="background:#f0f6ff">
           <tr>
@@ -60,6 +65,7 @@
           `<td style='padding:8px;border:1px solid #ddd'>${t.assignee||''}</td>`+
           `<td style='padding:8px;border:1px solid #ddd'>${t.status}</td>`+
           `<td style='padding:8px;border:1px solid #ddd'>`+
+          `<a href="task.html?id=${t.id}" class='btn' style='margin-right:4px'>Подробнее</a>`+
           (t.assignee? (t.assignee==currentUser?`<button onclick="release(${t.id})" class='btn'>Отдать</button>`:'') : `<button onclick="claim(${t.id})" class='btn'>Взять</button>`)+`</td>`;
         tbody.appendChild(tr);
       });
@@ -68,13 +74,29 @@
       fetch(API+`/tasks/${id}/claim`,{method:'POST',headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})
         .then(r=>{if(!r.ok) return alert('Ошибка'); loadTasks();});
     }
-    function release(id){
-      fetch(API+`/tasks/${id}/release`,{method:'POST',headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})
-        .then(r=>{if(!r.ok) return alert('Ошибка'); loadTasks();});
-    }
-    const currentUser = localStorage.getItem(tokenKey)?jwt_decode(localStorage.getItem(tokenKey)).uid:null;
-    document.addEventListener('DOMContentLoaded', loadTasks);
-  </script>
+      function release(id){
+        fetch(API+`/tasks/${id}/release`,{method:'POST',headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})
+          .then(r=>{if(!r.ok) return alert('Ошибка'); loadTasks();});
+      }
+      function exportCSV(){
+        fetch(API+'/tasks/export',{headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})
+          .then(r=>r.blob())
+          .then(blob=>{
+            const url=window.URL.createObjectURL(blob);
+            const a=document.createElement('a');
+            a.href=url;
+            a.download='tasks.csv';
+            a.click();
+            window.URL.revokeObjectURL(url);
+          });
+      }
+      const currentUser = localStorage.getItem(tokenKey)?jwt_decode(localStorage.getItem(tokenKey)).uid:null;
+      document.addEventListener('DOMContentLoaded', ()=>{
+        loadTasks();
+        const btn=document.getElementById('exportBtn');
+        if(btn) btn.addEventListener('click', exportCSV);
+      });
+    </script>
   <script src="https://cdn.jsdelivr.net/npm/jwt-decode@4/build/cjs/index.js"></script>
 </body>
 </html>

--- a/backend/static/tl-dashboard.html
+++ b/backend/static/tl-dashboard.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Панель тимлида</title>
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+</head>
+<body>
+<header class="header">
+  <span class="header-text">Панель тимлида</span>
+  <div class="dropdown">
+    <i id="menuToggle" class="fas fa-list" style="font-size:2rem;cursor:pointer"></i>
+    <nav id="dropdownMenu" class="dropdown-content">
+      <a href="index.html" class="dropdown-item">Главная</a>
+      <a href="tasks.html" class="dropdown-item">Задачи</a>
+      <a href="tl-dashboard.html" class="dropdown-item">TL Панель</a>
+      <a href="risk-log.html" class="dropdown-item">Риски</a>
+      <a href="reports.html" class="dropdown-item">Отчёты</a>
+    </nav>
+  </div>
+</header>
+<main class="main">
+  <section class="info-section">
+    <h2>Все задачи</h2>
+    <label>Фильтр:
+      <select id="filterSel">
+        <option value="all">Все</option>
+        <option value="risk">Риск</option>
+        <option value="overdue">Просрочено</option>
+      </select>
+    </label>
+    <table id="dashTable" style="width:100%;border-collapse:collapse;margin-top:1rem">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Название</th>
+          <th>Прогресс</th>
+          <th>Дедлайн</th>
+          <th>Приоритет</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <div style="margin-top:1rem" id="kpi"></div>
+  </section>
+</main>
+<script src="scripts.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jwt-decode@4/build/cjs/index.js"></script>
+<script>
+const API='/api', tokenKey='pyToken';
+const tbody=document.querySelector('#dashTable tbody');
+function load(){
+  fetch(API+'/tasks',{headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})
+    .then(r=>r.json()).then(show);
+}
+function show(list){
+  const f=document.getElementById('filterSel').value;
+  const now=new Date();
+  let risk=0,over=0;
+  tbody.innerHTML='';
+  list.forEach(t=>{
+    const deadline=t.deadline?new Date(t.deadline):null;
+    const isOver=deadline && deadline<now && t.progress<100;
+    const isRisk=t.progress<50 && deadline && (deadline-now)/86400000<=2;
+    if(isRisk) risk++; if(isOver) over++;
+    if(f==='risk' && !isRisk) return;
+    if(f==='overdue' && !isOver) return;
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${t.id}</td><td>${t.name}</td><td>${t.progress}%</td>`+
+      `<td>${deadline?deadline.toISOString().split('T')[0]:''}</td>`+
+      `<td>${t.priority}</td>`+
+      `<td><a href="task_edit.html?id=${t.id}">Редактировать</a></td>`;
+    tbody.appendChild(tr);
+  });
+  document.getElementById('kpi').textContent=`Рисков: ${risk} | Просрочено: ${over}`;
+}
+
+document.getElementById('filterSel').onchange=load;
+if(!localStorage.getItem(tokenKey)) location.replace('login.html');
+document.addEventListener('DOMContentLoaded',load);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend `Task` model with priority field and introduce `RiskEvent`
- add risk event creation when tasks are overdue
- add `/api/risk-events` and `/api/reports` endpoints
- export tasks with priority column
- implement TL dashboard, task editor, risk log and reports pages
- update existing menus to link to new pages

## Testing
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68471b9593648330ba98e02508418163