### PR TITLE
Add SSE for risk alerts

### DIFF
--- a/backend/static/styles.css
+++ b/backend/static/styles.css
@@ -264,3 +264,7 @@ h3 {
 .input-field.incorrect {
   background-color: var(--light-incorrect-color);
 }
+
+.alert-row{
+  background-color:#fff3cd;
+}

--- a/backend/static/tl-dashboard.html
+++ b/backend/static/tl-dashboard.html
@@ -56,6 +56,20 @@ function load(){
   fetch(API+'/tasks',{headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})
     .then(r=>r.json()).then(show);
 }
+function highlightTask(id){
+  const row=[...tbody.children].find(r=>r.firstElementChild.textContent==id);
+  if(row) row.classList.add('alert-row');
+}
+function storeAlert(ev){
+  const arr=JSON.parse(localStorage.getItem('unseenAlerts')||'[]');
+  arr.push(ev); localStorage.setItem('unseenAlerts',JSON.stringify(arr));
+}
+function highlightStored(){
+  const arr=JSON.parse(localStorage.getItem('unseenAlerts')||'[]');
+  arr.forEach(ev=>highlightTask(ev.task));
+  if(arr.length) localStorage.removeItem('unseenAlerts');
+}
+
 function show(list){
   const f=document.getElementById('filterSel').value;
   const now=new Date();
@@ -76,11 +90,21 @@ function show(list){
     tbody.appendChild(tr);
   });
   document.getElementById('kpi').textContent=`Рисков: ${risk} | Просрочено: ${over}`;
+  highlightStored();
 }
 
 document.getElementById('filterSel').onchange=load;
 if(!localStorage.getItem(tokenKey)) location.replace('login.html');
-document.addEventListener('DOMContentLoaded',load);
+function connect(){
+  const es=new EventSource(`${API}/risk-stream?token=${localStorage.getItem(tokenKey)}`);
+  es.onmessage=e=>{
+    const ev=JSON.parse(e.data);
+    highlightTask(ev.task);
+    storeAlert(ev);
+    alert(`Риск: задача ${ev.task} - ${ev.message}`);
+  };
+}
+document.addEventListener('DOMContentLoaded',()=>{load();connect();});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement risk event broadcasting using Server-Sent Events
- publish risk events when tasks trigger them
- listen for new events on TL dashboard and highlight tasks
- style highlighted rows

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68472f9604e08330a3a8becd709d4dc5