### PR TITLE
Add task descriptions

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -160,6 +160,7 @@ def task_dict(t: Task):
     return {
         "id": t.id,
         "name": t.name,
+        "description": t.description,
         "effort": t.effort,
         "deadline": t.deadline.isoformat() if t.deadline else None,
         "assignee": t.user_id,
@@ -179,6 +180,7 @@ def tasks():
         d = request.json
         t = Task(
             name=d["name"],
+            description=d.get("description"),
             effort=d.get("effort", 0),
             deadline=datetime.datetime.fromisoformat(d["deadline"]) if d.get("deadline") else None,
             status=d.get("status", "open"),
@@ -394,7 +396,7 @@ def update_task(tid):
         return jsonify({"msg": "forbidden"}), 403
     t = Task.query.get_or_404(tid)
     d = request.json
-    for k in ("name", "effort", "status", "priority"):
+    for k in ("name", "effort", "status", "priority", "description"):
         if k in d:
             setattr(t, k, d[k])
     if "deadline" in d:

--- a/backend/models.py
+++ b/backend/models.py
@@ -20,6 +20,7 @@ class Result(db.Model):
 class Task(db.Model):
     id       = db.Column(db.Integer, primary_key=True)
     name     = db.Column(db.String(120), nullable=False)
+    description = db.Column(db.String(200))
     effort   = db.Column(db.Integer)  # hours
     deadline = db.Column(db.DateTime)
     user_id  = db.Column(db.Integer, db.ForeignKey('user.id'))

--- a/backend/static/task.html
+++ b/backend/static/task.html
@@ -25,6 +25,7 @@
     <p>Трудоёмкость: <span id="taskEffort"></span></p>
     <p>Дедлайн: <span id="taskDeadline"></span></p>
     <p>Приоритет: <span id="taskPriority"></span></p>
+    <p id="taskDescription"></p>
     <div style="margin:1rem 0">
       <label>Прогресс: <span id="progVal">0</span>%</label>
       <input type="range" id="progress" min="0" max="100" value="0" style="width:100%">
@@ -54,6 +55,7 @@ function show(d){
   document.getElementById('taskEffort').textContent=d.effort;
   document.getElementById('taskDeadline').textContent=d.deadline?d.deadline.split('T')[0]:'';
   document.getElementById('taskPriority').textContent=d.priority;
+  document.getElementById('taskDescription').textContent=d.description||'';
   document.getElementById('progress').value=d.progress;
   document.getElementById('progVal').textContent=d.progress;
   const list=document.getElementById('comments');

--- a/backend/static/task_edit.html
+++ b/backend/static/task_edit.html
@@ -25,6 +25,8 @@
     <input id="deadline" type="date" style="width:100%">
     <label>Приоритет</label>
     <input id="priority" type="text" style="width:100%">
+    <label>Описание</label>
+    <textarea id="description" style="width:100%"></textarea>
     <div class="buttons" style="justify-content:center;margin-top:1rem">
       <button id="saveBtn" class="btn">Сохранить</button>
     </div>
@@ -40,6 +42,7 @@ function load(){
     .then(r=>r.json()).then(d=>{
       document.getElementById('effort').value=d.effort||0;
       document.getElementById('priority').value=d.priority||'';
+      document.getElementById('description').value=d.description||'';
       if(d.deadline) document.getElementById('deadline').value=d.deadline.split('T')[0];
     });
 }
@@ -47,7 +50,8 @@ function save(){
   const body={
     effort:parseInt(document.getElementById('effort').value||0),
     deadline:document.getElementById('deadline').value,
-    priority:document.getElementById('priority').value.trim()
+    priority:document.getElementById('priority').value.trim(),
+    description:document.getElementById('description').value.trim()
   };
   fetch(API+`/tasks/${id}`,{method:'PUT',headers:{'Content-Type':'application/json','Authorization':'Bearer '+localStorage.getItem(tokenKey)},body:JSON.stringify(body)})
     .then(()=>location.replace('tl-dashboard.html'));

--- a/migrations/001_add_description.sql
+++ b/migrations/001_add_description.sql
@@ -1,0 +1,1 @@
+ALTER TABLE task ADD COLUMN description VARCHAR(200);


### PR DESCRIPTION
## Summary
- add `description` column to `Task`
- migrate DB via SQL script
- send/receive `description` via task API
- display and edit description in task pages

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 backend/app.py` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68472fa054e083309809a85c4c8307e1