### PR TITLE
Implement subtasks

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -177,6 +177,7 @@ def task_dict(t: Task):
         "status": t.status,
         "progress": t.progress,
         "priority": t.priority,
+        "parent_id": t.parent_id,
     }
 
 
@@ -195,6 +196,7 @@ def tasks():
             deadline=datetime.datetime.fromisoformat(d["deadline"]) if d.get("deadline") else None,
             status=d.get("status", "open"),
             priority=d.get("priority", "normal"),
+            parent_id=d.get("parent_id"),
         )
         db.session.add(t)
         db.session.commit()

--- a/backend/models.py
+++ b/backend/models.py
@@ -27,6 +27,7 @@ class Task(db.Model):
     status   = db.Column(db.String(20), default='open')  # open|in_progress|done
     progress = db.Column(db.Integer, default=0)  # percent complete
     priority = db.Column(db.String(20), default='normal')
+    parent_id = db.Column(db.Integer, db.ForeignKey('task.id'))
 
 
 class Comment(db.Model):

--- a/backend/static/task_edit.html
+++ b/backend/static/task_edit.html
@@ -14,6 +14,7 @@
     <i id="menuToggle" class="fas fa-list" style="font-size:2rem;cursor:pointer"></i>
     <nav id="dropdownMenu" class="dropdown-content">
       <a href="tl-dashboard.html" class="dropdown-item">TL Панель</a>
+      <a href="#" id="splitBtn" class="dropdown-item">Разбить на под-задачи</a>
     </nav>
   </div>
 </header>
@@ -57,7 +58,23 @@ function save(){
     .then(()=>location.replace('tl-dashboard.html'));
 }
 if(!localStorage.getItem(tokenKey)) location.replace('login.html');
-document.addEventListener('DOMContentLoaded',()=>{load();document.getElementById('saveBtn').onclick=save;});
+function splitTasks(){
+  const names=prompt('Названия под-задач через запятую:');
+  if(!names) return;
+  const list=names.split(',').map(s=>s.trim()).filter(Boolean);
+  const token=localStorage.getItem(tokenKey);
+  Promise.all(list.map(n=>fetch(API+'/tasks',{
+    method:'POST',
+    headers:{'Content-Type':'application/json','Authorization':'Bearer '+token},
+    body:JSON.stringify({name:n,parent_id:id})
+  })) ).then(()=>location.reload());
+}
+document.addEventListener('DOMContentLoaded',()=>{
+  load();
+  document.getElementById('saveBtn').onclick=save;
+  const btn=document.getElementById('splitBtn');
+  if(btn) btn.onclick=splitTasks;
+});
 </script>
 </body>
 </html>

--- a/migrations/002_add_parent_id.sql
+++ b/migrations/002_add_parent_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE task ADD COLUMN parent_id INTEGER REFERENCES task(id);


### PR DESCRIPTION
## Summary
- support parent-child relationship in Task model
- allow creating tasks with optional parent_id
- enable adding subtasks via UI in task_edit page
- add DB migration for new column

## Testing
- `python -m py_compile backend/app.py backend/models.py`
- `python backend/app.py` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68473b976a04833087bcf3a7473584a5