### PR TITLE
Fix sample task assignees

### DIFF
--- a/backend/static/sample_data.js
+++ b/backend/static/sample_data.js
@@ -1,8 +1,9 @@
 // Простые заглушки для демонстрации работы интерфейса
 const SAMPLE_TASKS = [
-  {id: 1, name: 'Обновление календаря', effort: 4, deadline: '2025-06-20', assignee: 'alice', status: 'в процессе', progress: 40, priority: 'A'},
-  {id: 2, name: 'Написать отчёт', effort: 2, deadline: '2025-06-18', assignee: 'bob', status: 'выполнено', progress: 100, priority: 'B'},
-  {id: 3, name: 'Обсудить требования', effort: 1, deadline: '2025-06-22', assignee: '', status: 'открыта', progress: 0, priority: 'C'}
+  // "assignee" uses numeric identifiers to mirror real API data
+  {id: 1, name: 'Обновление календаря', effort: 4, deadline: '2025-06-20', assignee: 2, status: 'в процессе', progress: 40, priority: 'A'}, // alice
+  {id: 2, name: 'Написать отчёт', effort: 2, deadline: '2025-06-18', assignee: 3, status: 'выполнено', progress: 100, priority: 'B'}, // bob
+  {id: 3, name: 'Обсудить требования', effort: 1, deadline: '2025-06-22', assignee: null, status: 'открыта', progress: 0, priority: 'C'}
 ];
 
 const SAMPLE_RISKS = [


### PR DESCRIPTION
## Summary
- align sample task data with seeded numeric user IDs

## Testing
- `python3 - <<'EOF'
import json,urllib.request

def api(method,path,token=None,data=None):
    req=urllib.request.Request('http://127.0.0.1:5000'+path,method=method)
    req.add_header('Content-Type','application/json')
    if token:
        req.add_header('Authorization','Bearer '+token)
    if data is not None:
        req.data=json.dumps(data).encode()
    with urllib.request.urlopen(req) as r:
        return json.load(r)
login=api('POST','/api/login',data={'username':'alice','password':'alicepass'})
tasks=api('GET','/api/tasks',token=login['token'])
print(len(tasks), tasks[0]['assignee'])
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68476991727c8330a7c8f480d221140d