### PR TITLE
Ensure calendar scripts execute after DOM is ready

### DIFF
--- a/backend/static/modern_calendar.html
+++ b/backend/static/modern_calendar.html
@@ -213,7 +213,11 @@
     buildGrid();
   };
 
-  document.addEventListener('DOMContentLoaded', loadSlots);
+  if (document.readyState !== 'loading') {
+    loadSlots();
+  } else {
+    document.addEventListener('DOMContentLoaded', loadSlots);
+  }
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/js/all.min.js"></script>
 </body>

--- a/backend/static/scripts.js
+++ b/backend/static/scripts.js
@@ -1,4 +1,4 @@
-document.addEventListener("DOMContentLoaded", () => {
+function initMenu() {
   const menuToggle = document.getElementById("menuToggle");
   const dropdownMenu = document.getElementById("dropdownMenu");
   if (menuToggle && dropdownMenu) {
@@ -26,4 +26,10 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     }
   }
-});
+}
+
+if (document.readyState !== "loading") {
+  initMenu();
+} else {
+  document.addEventListener("DOMContentLoaded", initMenu);
+}


### PR DESCRIPTION
## Summary
- ensure navigation menu script initializes even if DOMContentLoaded has already fired
- call calendar initialization immediately when DOM is already loaded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68476b1e2aec8330a3ae71f4e97de109