### PR TITLE
Fix JWT role decoding

### DIFF
--- a/backend/static/scripts.js
+++ b/backend/static/scripts.js
@@ -15,7 +15,9 @@ function initMenu() {
     const token = localStorage.getItem("pyToken");
     if (token) {
       try {
-        const role = JSON.parse(atob(token.split(".")[1])).role;
+        const b64 = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");
+        const padded = b64 + "=".repeat((4 - b64.length % 4) % 4);
+        const role = JSON.parse(atob(padded)).role;
         if (role !== "teacher" && role !== "admin") {
           dropdownMenu.querySelectorAll(".teacher-link").forEach(el => {
             el.style.display = "none";


### PR DESCRIPTION
## Summary
- decode JWT using Base64URL before parsing role in `scripts.js`

## Testing
- `python -m py_compile backend/*.py`
- manual jsdom test confirming teacher links visible for role=teacher

------
https://chatgpt.com/codex/tasks/task_e_68476c87b03883308b9cd7080bef8b68