### PR TITLE
Add routes for task pages and fix links

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -52,6 +52,18 @@ def index():
     """Serve the login page (or index.html, change if needed)."""
     return app.send_static_file("login.html")
 
+# Route serving task details page by id
+@app.route("/task/<int:tid>")
+def task_page(tid: int):
+    """Return task.html for client-side rendering."""
+    return app.send_static_file("task.html")
+
+# Route serving task edit page by id
+@app.route("/task/edit/<int:tid>")
+def task_edit_page(tid: int):
+    """Return task_edit.html for editing tasks."""
+    return app.send_static_file("task_edit.html")
+
 # ── Helpers ─────────────────────────────────────────────────────────────────────
 
 def require_auth(role: str | None = None):

--- a/backend/static/task.html
+++ b/backend/static/task.html
@@ -50,8 +50,9 @@
 <script src="https://cdn.jsdelivr.net/npm/jwt-decode/build/jwt-decode.min.js"></script>
 <script>
 const API='/api', tokenKey='pyToken';
-const params=new URLSearchParams(location.search);
-const taskId=parseInt(params.get('id'));
+const pathMatch = location.pathname.match(/\/task\/(\d+)/);
+const taskId = pathMatch ? parseInt(pathMatch[1])
+  : parseInt(new URLSearchParams(location.search).get('id'));
 let currentUser=null;
 function load(){
   fetch(API+`/tasks/${taskId}`,{headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})

--- a/backend/static/task_edit.html
+++ b/backend/static/task_edit.html
@@ -44,7 +44,9 @@
 <script src="https://cdn.jsdelivr.net/npm/jwt-decode/build/jwt-decode.min.js"></script>
 <script>
 const API='/api', tokenKey='pyToken';
-const id=parseInt(new URLSearchParams(location.search).get('id'));
+const pathEdit = location.pathname.match(/\/task\/edit\/(\d+)/);
+const id = pathEdit ? parseInt(pathEdit[1])
+  : parseInt(new URLSearchParams(location.search).get('id'));
 function load(){
   fetch(API+`/tasks/${id}`,{headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})
     .then(r=>r.json()).then(d=>{

--- a/backend/static/tasks.html
+++ b/backend/static/tasks.html
@@ -68,7 +68,7 @@
           `<td>${t.assignee||''}</td>`+
           `<td>${t.status}</td>`+
           `<td>`+
-          `<a href="task.html?id=${t.id}" class='btn' style='margin-right:4px'>Подробнее</a>`+
+          `<a href="/task/${t.id}" class='btn' style='margin-right:4px'>Подробнее</a>`+
           (t.assignee? (t.assignee==currentUser?`<button onclick="release(${t.id})" class='btn'>Отдать</button>`:'') : `<button onclick="claim(${t.id})" class='btn'>Взять</button>`)+`</td>`;
         tbody.appendChild(tr);
       });

--- a/backend/static/tl-dashboard.html
+++ b/backend/static/tl-dashboard.html
@@ -94,7 +94,7 @@ function show(list){
     tr.innerHTML=`<td>${t.id}</td><td>${t.name}</td><td>${t.progress}%</td>`+
       `<td>${deadline?deadline.toISOString().split('T')[0]:''}</td>`+
       `<td>${t.priority}</td>`+
-      `<td><a href="task_edit.html?id=${t.id}">Редактировать</a></td>`;
+      `<td><a href="/task/edit/${t.id}">Редактировать</a></td>`;
     tbody.appendChild(tr);
   });
   const avg=count? (diff/count).toFixed(1):0;


### PR DESCRIPTION
## Summary
- serve static task pages on `/task/<id>` and `/task/edit/<id>`
- update tasks and TL dashboard links to use the new paths
- support path-based IDs in `task.html` and `task_edit.html`

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6847701e22908330acb1fa9ec62f69eb