### PR TITLE
Fix task page ID handling

### DIFF
--- a/backend/static/task.html
+++ b/backend/static/task.html
@@ -50,9 +50,13 @@
 <script src="https://cdn.jsdelivr.net/npm/jwt-decode/build/jwt-decode.min.js"></script>
 <script>
 const API='/api', tokenKey='pyToken';
-const pathMatch = location.pathname.match(/\/task\/(\d+)/);
-const taskId = pathMatch ? parseInt(pathMatch[1])
-  : parseInt(new URLSearchParams(location.search).get('id'));
+const params=new URLSearchParams(location.search);
+const pathMatch=location.pathname.match(/\/task\/(\d+)/);
+const idStr=pathMatch?pathMatch[1]:params.get('id');
+const taskId=idStr?parseInt(idStr):NaN;
+if(Number.isNaN(taskId)){
+  location.replace('tasks.html');
+}
 let currentUser=null;
 function load(){
   fetch(API+`/tasks/${taskId}`,{headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})


### PR DESCRIPTION
## Summary
- prevent `/api/tasks/NaN` calls by checking ID in task details script

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684771a601ec8330a900c7ca0fe98faa