### PR TITLE
Fix report parameter handling and errors

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -343,13 +343,15 @@ def reports():
     fmt = request.args.get("fmt", "csv")  # csv or json
 
     q = Task.query
-    if "from" in request.args:
+    from_arg = request.args.get("from")
+    to_arg = request.args.get("to")
+    if from_arg:
         q = q.filter(
-            Task.deadline >= datetime.datetime.fromisoformat(request.args["from"])
+            Task.deadline >= datetime.datetime.fromisoformat(from_arg)
         )
-    if "to" in request.args:
+    if to_arg:
         q = q.filter(
-            Task.deadline <= datetime.datetime.fromisoformat(request.args["to"])
+            Task.deadline <= datetime.datetime.fromisoformat(to_arg)
         )
     if kind == "overdue":
         now = datetime.datetime.utcnow()

--- a/backend/static/reports.html
+++ b/backend/static/reports.html
@@ -52,7 +52,10 @@ function params(){
   let kind='general';
   if(document.getElementById('kindOverdue').checked) kind='overdue';
   if(document.getElementById('kindByUser').checked) kind='by_user';
-  return `from=${from}&to=${to}&kind=${kind}`;
+  const params=new URLSearchParams({kind});
+  if(from) params.append('from',from);
+  if(to) params.append('to',to);
+  return params.toString();
 }
 function download(){
   const url=`${API}/reports?${params()}`;
@@ -66,7 +69,15 @@ function download(){
 function downloadPdf(){
   const url=`${API}/reports?fmt=json&${params()}`;
   fetch(url,{headers:{'Authorization':'Bearer '+localStorage.getItem(tokenKey)}})
-    .then(r=>r.json()).then(data=>{
+    .then(async r=>{
+      if(!r.ok){
+        const err=await r.json().catch(()=>({msg:'error'}));
+        alert(err.msg||'Ошибка');
+        throw new Error('bad response');
+      }
+      return r.json();
+    })
+    .then(data=>{
       const {jsPDF}=window.jspdf;
       const doc=new jsPDF();
       doc.setFontSize(16);


### PR DESCRIPTION
## Summary
- handle blank `from`/`to` params in `/api/reports`
- improve report page JS to skip empty params
- show alert on failed report request

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684775e32750833089618954ff92514e